### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Authorization Library [![Build Status](https://api.travis-ci.com/apache/fineract-cn-anubis.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-anubis)
+# Apache Fineract CN Authorization Library
 
 This project provides authorization for Apache Fineract CN services.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-anubis).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.